### PR TITLE
Fix The Container Entrypoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM golang:1.3.1-onbuild
 
-ENTRYPOINT ["/go/src/app/app"]
+ENTRYPOINT ["/go/bin/app"]


### PR DESCRIPTION
The application binary is installed in /go/bin. This fixes issue #2.