### PR TITLE
Use Golang 1.5.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.3.1-onbuild
+FROM golang:1.5.2-onbuild
 
 ENTRYPOINT ["/go/bin/app"]


### PR DESCRIPTION
1.3 has been removed from github.com/docker-library/golang. See this [commit](https://github.com/docker-library/golang/commit/7579f7e9257f5615c57f91edc786285fd8ef88ae).
